### PR TITLE
Add datetime property

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,12 +6,23 @@ The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.0.0/),
 and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
 
+## [1.1.4] - 2023-11-09
+
+### Added
+
+- `datetime` property.
+
+## [1.1.3] - 2023-10-09
+
+### Fixed
+
+- Honor Python 3.7 syntax .
+
 ## [1.1.2] - 2023-09-13
 
 ### Fixed
 
 - Properly exported symbols as per https://github.com/microsoft/pylance-release/issues/2953#issuecomment-1168408943.
-
 
 ## [1.1.1] - 2023-08-18
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -4,7 +4,7 @@ build-backend = "setuptools.build_meta"
 
 [project]
 name = "tsidpy"
-version = "1.1.3"
+version = "1.1.4"
 authors = [
   { name="Luis Medel", email="luis@luismedel.com" },
 ]

--- a/src/tsidpy/tsid.py
+++ b/src/tsidpy/tsid.py
@@ -91,6 +91,16 @@ class TSID:
         return self._epoch + (self.__number >> RANDOM_BITS)
 
     @property
+    def datetime(self) -> datetime:
+        """Datetime corresponding with the tiimestamp component
+           of the TSID.
+
+        >>> TSID(0).datetime == datetime.fromtimestamp(TSID_EPOCH / 1000)
+        True
+        """
+        return datetime.fromtimestamp(self.timestamp / 1000)
+
+    @property
     def random(self) -> int:
         """Returns the random component of the TSID.
            This compomnent contains the node and counter

--- a/tests/generator_test.py
+++ b/tests/generator_test.py
@@ -20,7 +20,7 @@ def print_tsid(t: TSID) -> None:
 
 
 if __name__ == '__main__':
-    g: TSIDGenerator()
+    g = TSIDGenerator()
     for _ in range(10):
         print_tsid(g.create())
     time.sleep(0.1)


### PR DESCRIPTION
Adds a new `datetime` property to `TSID` objects.

This new property saves the user to have to convert the milliseconds of `timestamp` to seconds to get the actual datetime value.

Also:
- Adds specific tests.
- Fixes a dumb error in the generator test script.